### PR TITLE
Make "transform" public and more reusable.

### DIFF
--- a/src/mixed.rs
+++ b/src/mixed.rs
@@ -22,7 +22,7 @@ pub trait MixedCase: ToOwned {
 
 impl MixedCase for str {
     fn to_mixed_case(&self) -> String {
-        ::transform(self, |s, out| {
+        ::transform(self, |s, out: &mut String| {
             if out.is_empty() { ::lowercase(s, out); }
             else { ::capitalize(s, out) }
         }, |_| {})


### PR DESCRIPTION
Hi,

I was looking for a way to split words in a similar way to `heck`, in a crate that already uses `heck`.

The obvious way would be to use snake_case and split on underscores, but I thought it would be more useful to make `transform` reusable to directly produce a vector (and other collections), so here it is.

I understand it does not fit the intended use case of `heck`, so I will understand if you refuse this PR.

Thanks!