### PR TITLE
heck is entirely dual licensed by MIT and Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Bug reports & fixes always welcome. :-)
 
 ### License
 
-heck is primarily distributed under the terms of both the MIT license and the
+heck is distributed under the terms of both the MIT license and the
 Apache License (Version 2.0).
 
 See LICENSE-APACHE and LICENSE-MIT for details.


### PR DESCRIPTION
According to https://github.com/withoutboats/heck/issues/9, the heck library is entirely dual licensed under MIT and Apache 2.0.

Closes #9.

@withoutboats, if this is accepted, could we have a new version published to make sure the artifact on crates.io includes this phrasing. Thanks so much!