### PR TITLE
Fix issue where a snake was being mistaken for a camel

### DIFF
--- a/src/snake.rs
+++ b/src/snake.rs
@@ -1,4 +1,4 @@
-/// This trait defines a camel case conversion.
+/// This trait defines a snake case conversion.
 ///
 /// In snake_case, word boundaries are indicated by underscores.
 ///


### PR DESCRIPTION
camels dont event look like sneks smh. maybe the snek ate a camel or something.

...In all seriousness, this is just a minor documentation fix. `SnakeCase` was getting defined as "a camel case conversion", rather than "a snake case conversion", which this addresses.