### PR TITLE
Fixed typo in snake.rs doc

### DIFF
--- a/src/snake.rs
+++ b/src/snake.rs
@@ -1,4 +1,4 @@
-/// This trait defines a camel case conversion.
+/// This trait defines a snake case conversion.
 ///
 /// In snake_case, word boundaries are indicated by underscores.
 ///


### PR DESCRIPTION
Don't tell me you called it "camel" instead of "snake" because you didn't want to step on a snek.