### PR TITLE
ConvertCase trait as a wrapper for other convert case functions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,16 +12,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    # Use MSRV for the build job
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.32
+        default: true
+        profile: minimal
+    - name: Build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+    # Use stable for other jobs
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         default: true
         profile: minimal
         components: rustfmt, clippy
-    - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,5 @@ Breaking changes:
 
 * Rename all traits from `SomeCase` to `ToSomeCase`, matching `std`s convention
   of beginning trait names with a verb (`ToOwned`, `AsRef`, …)
+* Rename `ToMixedCase` to `ToLowerCamelCase`
+* Rename `ToCamelCase` to `ToUpperCamelCase`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@ Breaking changes:
   of beginning trait names with a verb (`ToOwned`, `AsRef`, …)
 * Rename `ToMixedCase` to `ToLowerCamelCase`
 * Rename `ToCamelCase` to `ToUpperCamelCase`
+* Add `ToPascalCase` as an alias to `ToUpperCamelCase`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# 0.4.0 (unreleased)
+
+Breaking changes:
+
+* Rename all traits from `SomeCase` to `ToSomeCase`, matching `std`s convention
+  of beginning trait names with a verb (`ToOwned`, `AsRef`, …)

--- a/src/camel.rs
+++ b/src/camel.rs
@@ -8,17 +8,17 @@ use crate::{capitalize, transform};
 /// ## Example:
 ///
 /// ```rust
-/// use heck::CamelCase;
+/// use heck::ToCamelCase;
 ///
 /// let sentence = "We are not in the least afraid of ruins.";
 /// assert_eq!(sentence.to_camel_case(), "WeAreNotInTheLeastAfraidOfRuins");
 /// ```
-pub trait CamelCase: ToOwned {
+pub trait ToCamelCase: ToOwned {
     /// Convert this type to camel case.
     fn to_camel_case(&self) -> Self::Owned;
 }
 
-impl CamelCase for str {
+impl ToCamelCase for str {
     fn to_camel_case(&self) -> String {
         transform(self, capitalize, |_| {})
     }
@@ -26,7 +26,7 @@ impl CamelCase for str {
 
 #[cfg(test)]
 mod tests {
-    use super::CamelCase;
+    use super::ToCamelCase;
 
     macro_rules! t {
         ($t:ident : $s1:expr => $s2:expr) => {

--- a/src/convert_case.rs
+++ b/src/convert_case.rs
@@ -72,91 +72,30 @@ impl ConvertCase for str {
 mod tests {
     use crate::{Case, ConvertCase, ConvertCaseOpt};
 
-    #[test]
-    fn number_starts_word_kebab_simple() {
-        assert_eq!(
-            "aes128".convert_case(ConvertCaseOpt {
-                case: Case::Kebab,
-                number_starts_word: true
-            }),
-            "aes-128"
-        );
+    macro_rules! t {
+        ($t:ident: $s1:expr, $c:ident,  $n:ident  => $s2:expr) => {
+            #[test]
+            fn $t() {
+                assert_eq!(
+                    $s1.convert_case(ConvertCaseOpt {
+                        case: Case::$c,
+                        number_starts_word: $n
+                    }),
+                    $s2
+                )
+            }
+        };
     }
 
-    #[test]
-    fn number_starts_word_kebab_complex() {
-        assert_eq!(
-            "aes128Key".convert_case(ConvertCaseOpt {
-                case: Case::Kebab,
-                number_starts_word: true
-            }),
-            "aes-128-key"
-        );
-    }
-
-    #[test]
-    fn number_starts_word_kebab_complex_underscore() {
-        assert_eq!(
-            "aes128 Key".convert_case(ConvertCaseOpt {
-                case: Case::Kebab,
-                number_starts_word: true
-            }),
-            "aes-128-key"
-        );
-    }
-
-    #[test]
-    fn number_starts_word_false_kebab_complex_underscore() {
-        assert_eq!(
-            "aes128 Key".convert_case(ConvertCaseOpt {
-                case: Case::Kebab,
-                number_starts_word: false
-            }),
-            "aes128-key"
-        );
-    }
-
-    #[test]
-    fn number_starts_word_true_title_case() {
-        assert_eq!(
-            "AES128BitKey".convert_case(ConvertCaseOpt {
-                case: Case::Title,
-                number_starts_word: true
-            }),
-            "Aes 128 Bit Key"
-        );
-    }
-
-    #[test]
-    fn number_starts_word_true_snake_case() {
-        assert_eq!(
-            "99BOTTLES".convert_case(ConvertCaseOpt {
-                case: Case::Snake,
-                number_starts_word: true
-            }),
-            "99_bottles"
-        );
-    }
-
-    #[test]
-    fn number_starts_word_true_snake_case_2() {
-        assert_eq!(
-            "abc123DEF456".convert_case(ConvertCaseOpt {
-                case: Case::Snake,
-                number_starts_word: true
-            }),
-            "abc_123_def_456"
-        );
-    }
-
-    #[test]
-    fn number_starts_word_true_snake_case_3() {
-        assert_eq!(
-            "ABC123dEEf456FOO".convert_case(ConvertCaseOpt {
-                case: Case::Snake,
-                number_starts_word: true
-            }),
-            "abc_123_d_e_ef_456_foo"
-        );
-    }
+    t!(test1: "AES 128 bit key", LowerCamel, false => "aes128BitKey");
+    t!(test2: "AES 128 bit key", LowerCamel, true => "aes128BitKey");
+    t!(test3: "AES 128 bit key", Kebab, true => "aes-128-bit-key");
+    t!(test4: "99BOTTLES", Snake, false => "99bottles");
+    t!(test5: "99BOTTLES", Snake, true => "99_bottles");
+    t!(test6: "ABC123dEEf456FOO", Snake, false => "abc123d_e_ef456_foo");
+    t!(test7: "ABC123dEEf456FOO", Snake, true => "abc_123_d_e_ef_456_foo");
+    t!(test8: "XMLHttpRequest404", Title, false => "Xml Http Request404");
+    t!(test9: "XMLHttpRequest404", Title, true => "Xml Http Request 404");
+    t!(test10: "this-contains_ ALLKinds OfWord_Boundaries_1Also", Kebab, false => "this-contains-all-kinds-of-word-boundaries-1also");
+    t!(test11: "this-contains_ ALLKinds OfWord_Boundaries_1Also", Kebab, true => "this-contains-all-kinds-of-word-boundaries-1-also");
 }

--- a/src/convert_case.rs
+++ b/src/convert_case.rs
@@ -1,0 +1,162 @@
+use crate::kebab::to_kebab;
+use crate::lower_camel::to_lower_camel_case;
+use crate::shouty_kebab::to_shouty_kebab_case;
+use crate::shouty_snake::to_shouty_snake_case;
+use crate::snake::to_snake_case;
+use crate::title::to_title_case;
+use crate::upper_camel::to_upper_camel_case;
+
+/// This trait defines a wrapper function for other case-conversion functions
+/// in that this can tweak the behaviour of those functions based on customization options
+///
+///
+/// ## Example:
+/// ```rust
+///
+/// use heck::{ConvertCase, ConvertCaseOpt, Case};
+///
+/// let sentence = "Aes128";
+/// assert_eq!(sentence.convert_case(ConvertCaseOpt { case: Case::ShoutyKebab, number_starts_word: true }),
+/// "AES-128");
+///
+
+pub trait ConvertCase: ToOwned {
+    /// Convert this type to supported cases with options
+    fn convert_case(&self, opt: ConvertCaseOpt) -> String;
+}
+
+/// Options to tweak how convert_case will behave
+pub struct ConvertCaseOpt {
+    /// supported case
+    pub case: Case,
+    /// whether numbers should start a new word
+    pub number_starts_word: bool,
+}
+
+/// supported cases
+pub enum Case {
+    /// kebab-case
+    Kebab,
+    /// lowerCamelCase
+    LowerCamel,
+    /// SHOUT-KEBAB-CASE
+    ShoutyKebab,
+    /// SHOUTY_SNAKE_CASE
+    ShoutySnake,
+    /// snake_case
+    Snake,
+    /// Title Case
+    Title,
+    /// UpperCamelCase
+    UpperCamel,
+}
+
+pub fn convert_case(s: &str, opt: ConvertCaseOpt) -> String {
+    match opt.case {
+        Case::Kebab => to_kebab(s, opt.number_starts_word),
+        Case::LowerCamel => to_lower_camel_case(s, opt.number_starts_word),
+        Case::ShoutyKebab => to_shouty_kebab_case(s, opt.number_starts_word),
+        Case::ShoutySnake => to_shouty_snake_case(s, opt.number_starts_word),
+        Case::Snake => to_snake_case(s, opt.number_starts_word),
+        Case::Title => to_title_case(s, opt.number_starts_word),
+        Case::UpperCamel => to_upper_camel_case(s, opt.number_starts_word),
+    }
+}
+impl ConvertCase for str {
+    fn convert_case(&self, opt: ConvertCaseOpt) -> Self::Owned {
+        convert_case(self, opt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Case, ConvertCase, ConvertCaseOpt};
+
+    #[test]
+    fn number_starts_word_kebab_simple() {
+        assert_eq!(
+            "aes128".convert_case(ConvertCaseOpt {
+                case: Case::Kebab,
+                number_starts_word: true
+            }),
+            "aes-128"
+        );
+    }
+
+    #[test]
+    fn number_starts_word_kebab_complex() {
+        assert_eq!(
+            "aes128Key".convert_case(ConvertCaseOpt {
+                case: Case::Kebab,
+                number_starts_word: true
+            }),
+            "aes-128-key"
+        );
+    }
+
+    #[test]
+    fn number_starts_word_kebab_complex_underscore() {
+        assert_eq!(
+            "aes128 Key".convert_case(ConvertCaseOpt {
+                case: Case::Kebab,
+                number_starts_word: true
+            }),
+            "aes-128-key"
+        );
+    }
+
+    #[test]
+    fn number_starts_word_false_kebab_complex_underscore() {
+        assert_eq!(
+            "aes128 Key".convert_case(ConvertCaseOpt {
+                case: Case::Kebab,
+                number_starts_word: false
+            }),
+            "aes128-key"
+        );
+    }
+
+    #[test]
+    fn number_starts_word_true_title_case() {
+        assert_eq!(
+            "AES128BitKey".convert_case(ConvertCaseOpt {
+                case: Case::Title,
+                number_starts_word: true
+            }),
+            "Aes 128 Bit Key"
+        );
+    }
+
+    #[test]
+    fn number_starts_word_true_snake_case() {
+        assert_eq!(
+            "99BOTTLES".convert_case(ConvertCaseOpt {
+                case: Case::Snake,
+                number_starts_word: true
+            }),
+            "99_bottles"
+        );
+    }
+
+    #[test]
+    fn number_starts_word_true_snake_case_2() {
+        assert_eq!(
+            "abc123DEF456".convert_case(ConvertCaseOpt {
+                case: Case::Snake,
+                number_starts_word: true
+            }),
+            "abc_123_def_456"
+        );
+    }
+
+    #[test]
+    fn number_starts_word_true_snake_case_3() {
+        assert_eq!(
+            "ABC123dEEf456FOO".convert_case(ConvertCaseOpt {
+                case: Case::Snake,
+                number_starts_word: true
+            }),
+            "abc_123_d_e_ef_456_foo"
+        );
+    }
+}

--- a/src/kebab.rs
+++ b/src/kebab.rs
@@ -7,17 +7,17 @@ use crate::{lowercase, transform};
 /// ## Example:
 ///
 /// ```rust
-/// use heck::KebabCase;
+/// use heck::ToKebabCase;
 ///
 /// let sentence = "We are going to inherit the earth.";
 /// assert_eq!(sentence.to_kebab_case(), "we-are-going-to-inherit-the-earth");
 /// ```
-pub trait KebabCase: ToOwned {
+pub trait ToKebabCase: ToOwned {
     /// Convert this type to kebab case.
     fn to_kebab_case(&self) -> Self::Owned;
 }
 
-impl KebabCase for str {
+impl ToKebabCase for str {
     fn to_kebab_case(&self) -> Self::Owned {
         transform(self, lowercase, |s| s.push('-'))
     }
@@ -25,7 +25,7 @@ impl KebabCase for str {
 
 #[cfg(test)]
 mod tests {
-    use super::KebabCase;
+    use super::ToKebabCase;
 
     macro_rules! t {
         ($t:ident : $s1:expr => $s2:expr) => {

--- a/src/kebab.rs
+++ b/src/kebab.rs
@@ -1,4 +1,5 @@
-use crate::{lowercase, transform};
+use crate::{lowercase, transform, ConvertCaseOpt, Case};
+use crate::convert_case::convert_case;
 
 /// This trait defines a kebab case conversion.
 ///
@@ -17,9 +18,13 @@ pub trait ToKebabCase: ToOwned {
     fn to_kebab_case(&self) -> Self::Owned;
 }
 
+pub fn to_kebab(s: &str, number_starts_word: bool) -> String {
+    transform(s, number_starts_word, lowercase, |s| s.push('-'))
+}
+
 impl ToKebabCase for str {
     fn to_kebab_case(&self) -> Self::Owned {
-        transform(self, lowercase, |s| s.push('-'))
+        convert_case(&self, ConvertCaseOpt {case: Case::Kebab, number_starts_word: false})
     }
 }
 

--- a/src/kebab.rs
+++ b/src/kebab.rs
@@ -1,5 +1,5 @@
-use crate::{lowercase, transform, ConvertCaseOpt, Case};
 use crate::convert_case::convert_case;
+use crate::{lowercase, transform, Case, ConvertCaseOpt};
 
 /// This trait defines a kebab case conversion.
 ///
@@ -24,7 +24,13 @@ pub fn to_kebab(s: &str, number_starts_word: bool) -> String {
 
 impl ToKebabCase for str {
     fn to_kebab_case(&self) -> Self::Owned {
-        convert_case(&self, ConvertCaseOpt {case: Case::Kebab, number_starts_word: false})
+        convert_case(
+            &self,
+            ConvertCaseOpt {
+                case: Case::Kebab,
+                number_starts_word: false,
+            },
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,13 +47,13 @@ mod shouty_snake;
 mod snake;
 mod title;
 
-pub use camel::CamelCase;
-pub use kebab::KebabCase;
-pub use mixed::MixedCase;
-pub use shouty_kebab::ShoutyKebabCase;
-pub use shouty_snake::{ShoutySnakeCase, ShoutySnekCase};
-pub use snake::{SnakeCase, SnekCase};
-pub use title::TitleCase;
+pub use camel::ToCamelCase;
+pub use kebab::ToKebabCase;
+pub use mixed::ToMixedCase;
+pub use shouty_kebab::ToShoutyKebabCase;
+pub use shouty_snake::{ToShoutySnakeCase, ToShoutySnekCase};
+pub use snake::{ToSnakeCase, ToSnekCase};
+pub use title::ToTitleCase;
 
 use unicode_segmentation::UnicodeSegmentation;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,21 +40,21 @@
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 
-mod camel;
 mod kebab;
-mod mixed;
+mod lower_camel;
 mod shouty_kebab;
 mod shouty_snake;
 mod snake;
 mod title;
+mod upper_camel;
 
-pub use camel::ToCamelCase;
 pub use kebab::ToKebabCase;
-pub use mixed::ToMixedCase;
+pub use lower_camel::ToLowerCamelCase;
 pub use shouty_kebab::ToShoutyKebabCase;
 pub use shouty_snake::{ToShoutySnakeCase, ToShoutySnekCase};
 pub use snake::{ToSnakeCase, ToSnekCase};
 pub use title::ToTitleCase;
+pub use upper_camel::ToUpperCamelCase;
 
 use unicode_segmentation::UnicodeSegmentation;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 //! 6. Title Case
 //! 7. SHOUTY-KEBAB-CASE
 #![deny(missing_docs)]
+#![forbid(unsafe_code)]
 
 mod camel;
 mod kebab;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 
+mod convert_case;
 mod kebab;
 mod lower_camel;
 mod shouty_kebab;
@@ -47,8 +48,8 @@ mod shouty_snake;
 mod snake;
 mod title;
 mod upper_camel;
-mod convert_case;
 
+pub use convert_case::{Case, ConvertCase, ConvertCaseOpt};
 pub use kebab::ToKebabCase;
 pub use lower_camel::ToLowerCamelCase;
 pub use shouty_kebab::ToShoutyKebabCase;
@@ -56,7 +57,6 @@ pub use shouty_snake::{ToShoutySnakeCase, ToShoutySnekCase};
 pub use snake::{ToSnakeCase, ToSnekCase};
 pub use title::ToTitleCase;
 pub use upper_camel::{ToPascalCase, ToUpperCamelCase};
-pub use convert_case::{ConvertCase, Case, ConvertCaseOpt};
 
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -84,7 +84,7 @@ where
         /// The previous cased character in the current word is uppercase.
         Uppercase,
         /// The previous cased character in the current word is numeric
-        Numeric
+        Numeric,
     }
 
     let mut out = String::new();
@@ -124,10 +124,15 @@ where
                 // When number_starts_word is false: Word boundary after if next is underscore or current is
                 // not uppercase and next is uppercase
                 // When number_starts_word is true: word boundary after when mode changes from alpha to numeric or numeric to alpha
-                if next == '_' ||
-                    (next_mode == WordMode::Lowercase && next.is_uppercase()) ||
-                        (number_starts_word && next_mode == WordMode::Numeric && (next.is_uppercase() || next.is_lowercase())) ||
-                        (number_starts_word && next.is_numeric() && (next_mode == WordMode::Lowercase || next_mode == WordMode::Uppercase)) {
+                if next == '_'
+                    || (next_mode == WordMode::Lowercase && next.is_uppercase())
+                    || (number_starts_word
+                        && next_mode == WordMode::Numeric
+                        && (next.is_uppercase() || next.is_lowercase()))
+                    || (number_starts_word
+                        && next.is_numeric()
+                        && (next_mode == WordMode::Lowercase || next_mode == WordMode::Uppercase))
+                {
                     if !first_word {
                         boundary(&mut out);
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub use shouty_kebab::ToShoutyKebabCase;
 pub use shouty_snake::{ToShoutySnakeCase, ToShoutySnekCase};
 pub use snake::{ToSnakeCase, ToSnekCase};
 pub use title::ToTitleCase;
-pub use upper_camel::ToUpperCamelCase;
+pub use upper_camel::{ToPascalCase, ToUpperCamelCase};
 
 use unicode_segmentation::UnicodeSegmentation;
 

--- a/src/lower_camel.rs
+++ b/src/lower_camel.rs
@@ -1,5 +1,5 @@
-use crate::{capitalize, lowercase, transform, ConvertCaseOpt, Case};
 use crate::convert_case::convert_case;
+use crate::{capitalize, lowercase, transform, Case, ConvertCaseOpt};
 
 /// This trait defines a lower camel case conversion.
 ///
@@ -21,7 +21,8 @@ pub trait ToLowerCamelCase: ToOwned {
 
 pub fn to_lower_camel_case(s: &str, number_starts_word: bool) -> String {
     transform(
-        s, number_starts_word,
+        s,
+        number_starts_word,
         |s, out| {
             if out.is_empty() {
                 lowercase(s, out);
@@ -35,7 +36,13 @@ pub fn to_lower_camel_case(s: &str, number_starts_word: bool) -> String {
 
 impl ToLowerCamelCase for str {
     fn to_lower_camel_case(&self) -> Self::Owned {
-        convert_case(&self, ConvertCaseOpt {case: Case::LowerCamel, number_starts_word: false})
+        convert_case(
+            &self,
+            ConvertCaseOpt {
+                case: Case::LowerCamel,
+                number_starts_word: false,
+            },
+        )
     }
 }
 

--- a/src/lower_camel.rs
+++ b/src/lower_camel.rs
@@ -1,4 +1,5 @@
-use crate::{capitalize, lowercase, transform};
+use crate::{capitalize, lowercase, transform, ConvertCaseOpt, Case};
+use crate::convert_case::convert_case;
 
 /// This trait defines a lower camel case conversion.
 ///
@@ -18,19 +19,23 @@ pub trait ToLowerCamelCase: ToOwned {
     fn to_lower_camel_case(&self) -> Self::Owned;
 }
 
+pub fn to_lower_camel_case(s: &str, number_starts_word: bool) -> String {
+    transform(
+        s, number_starts_word,
+        |s, out| {
+            if out.is_empty() {
+                lowercase(s, out);
+            } else {
+                capitalize(s, out)
+            }
+        },
+        |_| {},
+    )
+}
+
 impl ToLowerCamelCase for str {
-    fn to_lower_camel_case(&self) -> String {
-        transform(
-            self,
-            |s, out| {
-                if out.is_empty() {
-                    lowercase(s, out);
-                } else {
-                    capitalize(s, out)
-                }
-            },
-            |_| {},
-        )
+    fn to_lower_camel_case(&self) -> Self::Owned {
+        convert_case(&self, ConvertCaseOpt {case: Case::LowerCamel, number_starts_word: false})
     }
 }
 

--- a/src/lower_camel.rs
+++ b/src/lower_camel.rs
@@ -1,25 +1,25 @@
 use crate::{capitalize, lowercase, transform};
 
-/// This trait defines a mixed case conversion.
+/// This trait defines a lower camel case conversion.
 ///
-/// In mixedCase, word boundaries are indicated by capital letters, excepting
-/// the first word.
+/// In lowerCamelCase, word boundaries are indicated by capital letters,
+/// excepting the first word.
 ///
 /// ## Example:
 ///
 /// ```rust
-/// use heck::ToMixedCase;
+/// use heck::ToLowerCamelCase;
 ///
 /// let sentence = "It is we who built these palaces and cities.";
-/// assert_eq!(sentence.to_mixed_case(), "itIsWeWhoBuiltThesePalacesAndCities");
+/// assert_eq!(sentence.to_lower_camel_case(), "itIsWeWhoBuiltThesePalacesAndCities");
 /// ```
-pub trait ToMixedCase: ToOwned {
-    /// Convert this type to mixed case.
-    fn to_mixed_case(&self) -> Self::Owned;
+pub trait ToLowerCamelCase: ToOwned {
+    /// Convert this type to lower camel case.
+    fn to_lower_camel_case(&self) -> Self::Owned;
 }
 
-impl ToMixedCase for str {
-    fn to_mixed_case(&self) -> String {
+impl ToLowerCamelCase for str {
+    fn to_lower_camel_case(&self) -> String {
         transform(
             self,
             |s, out| {
@@ -36,13 +36,13 @@ impl ToMixedCase for str {
 
 #[cfg(test)]
 mod tests {
-    use super::ToMixedCase;
+    use super::ToLowerCamelCase;
 
     macro_rules! t {
         ($t:ident : $s1:expr => $s2:expr) => {
             #[test]
             fn $t() {
-                assert_eq!($s1.to_mixed_case(), $s2)
+                assert_eq!($s1.to_lower_camel_case(), $s2)
             }
         };
     }

--- a/src/mixed.rs
+++ b/src/mixed.rs
@@ -8,17 +8,17 @@ use crate::{capitalize, lowercase, transform};
 /// ## Example:
 ///
 /// ```rust
-/// use heck::MixedCase;
+/// use heck::ToMixedCase;
 ///
 /// let sentence = "It is we who built these palaces and cities.";
 /// assert_eq!(sentence.to_mixed_case(), "itIsWeWhoBuiltThesePalacesAndCities");
 /// ```
-pub trait MixedCase: ToOwned {
+pub trait ToMixedCase: ToOwned {
     /// Convert this type to mixed case.
     fn to_mixed_case(&self) -> Self::Owned;
 }
 
-impl MixedCase for str {
+impl ToMixedCase for str {
     fn to_mixed_case(&self) -> String {
         transform(
             self,
@@ -36,7 +36,7 @@ impl MixedCase for str {
 
 #[cfg(test)]
 mod tests {
-    use super::MixedCase;
+    use super::ToMixedCase;
 
     macro_rules! t {
         ($t:ident : $s1:expr => $s2:expr) => {

--- a/src/shouty_kebab.rs
+++ b/src/shouty_kebab.rs
@@ -1,5 +1,5 @@
-use crate::{transform, uppercase, ConvertCaseOpt, Case};
 use crate::convert_case::convert_case;
+use crate::{transform, uppercase, Case, ConvertCaseOpt};
 
 /// This trait defines a shouty kebab case conversion.
 ///
@@ -25,7 +25,13 @@ pub fn to_shouty_kebab_case(s: &str, number_starts_word: bool) -> String {
 
 impl ToShoutyKebabCase for str {
     fn to_shouty_kebab_case(&self) -> Self::Owned {
-        convert_case(&self, ConvertCaseOpt {case: Case::ShoutyKebab, number_starts_word: false})
+        convert_case(
+            &self,
+            ConvertCaseOpt {
+                case: Case::ShoutyKebab,
+                number_starts_word: false,
+            },
+        )
     }
 }
 

--- a/src/shouty_kebab.rs
+++ b/src/shouty_kebab.rs
@@ -8,17 +8,17 @@ use crate::{transform, uppercase};
 /// ## Example:
 ///
 /// ```rust
-/// use heck::ShoutyKebabCase;
+/// use heck::ToShoutyKebabCase;
 ///
 /// let sentence = "We are going to inherit the earth.";
 /// assert_eq!(sentence.to_shouty_kebab_case(), "WE-ARE-GOING-TO-INHERIT-THE-EARTH");
 /// ```
-pub trait ShoutyKebabCase: ToOwned {
+pub trait ToShoutyKebabCase: ToOwned {
     /// Convert this type to shouty kebab case.
     fn to_shouty_kebab_case(&self) -> Self::Owned;
 }
 
-impl ShoutyKebabCase for str {
+impl ToShoutyKebabCase for str {
     fn to_shouty_kebab_case(&self) -> Self::Owned {
         transform(self, uppercase, |s| s.push('-'))
     }
@@ -26,7 +26,7 @@ impl ShoutyKebabCase for str {
 
 #[cfg(test)]
 mod tests {
-    use super::ShoutyKebabCase;
+    use super::ToShoutyKebabCase;
 
     macro_rules! t {
         ($t:ident : $s1:expr => $s2:expr) => {

--- a/src/shouty_kebab.rs
+++ b/src/shouty_kebab.rs
@@ -1,4 +1,5 @@
-use crate::{transform, uppercase};
+use crate::{transform, uppercase, ConvertCaseOpt, Case};
+use crate::convert_case::convert_case;
 
 /// This trait defines a shouty kebab case conversion.
 ///
@@ -18,9 +19,13 @@ pub trait ToShoutyKebabCase: ToOwned {
     fn to_shouty_kebab_case(&self) -> Self::Owned;
 }
 
+pub fn to_shouty_kebab_case(s: &str, number_starts_word: bool) -> String {
+    transform(s, number_starts_word, uppercase, |s| s.push('-'))
+}
+
 impl ToShoutyKebabCase for str {
     fn to_shouty_kebab_case(&self) -> Self::Owned {
-        transform(self, uppercase, |s| s.push('-'))
+        convert_case(&self, ConvertCaseOpt {case: Case::ShoutyKebab, number_starts_word: false})
     }
 }
 

--- a/src/shouty_snake.rs
+++ b/src/shouty_snake.rs
@@ -1,4 +1,5 @@
-use crate::{transform, uppercase};
+use crate::{transform, uppercase, ConvertCaseOpt, Case};
+use crate::convert_case::convert_case;
 
 /// This trait defines a shouty snake case conversion.
 ///
@@ -32,9 +33,13 @@ impl<T: ?Sized + ToShoutySnakeCase> ToShoutySnekCase for T {
     }
 }
 
+pub fn to_shouty_snake_case(s: &str, numbers_starts_word: bool) -> String {
+    transform(s, numbers_starts_word, uppercase, |s| s.push('_'))
+}
+
 impl ToShoutySnakeCase for str {
     fn to_shouty_snake_case(&self) -> Self::Owned {
-        transform(self, uppercase, |s| s.push('_'))
+        convert_case(&self, ConvertCaseOpt {case: Case::ShoutySnake, number_starts_word: false})
     }
 }
 

--- a/src/shouty_snake.rs
+++ b/src/shouty_snake.rs
@@ -8,31 +8,31 @@ use crate::{transform, uppercase};
 /// ## Example:
 ///
 /// ```rust
-/// use heck::ShoutySnakeCase;
-///     
+/// use heck::ToShoutySnakeCase;
+///
 /// let sentence = "That world is growing in this minute.";
 /// assert_eq!(sentence.to_shouty_snake_case(), "THAT_WORLD_IS_GROWING_IN_THIS_MINUTE");
 /// ```
-pub trait ShoutySnakeCase: ToOwned {
+pub trait ToShoutySnakeCase: ToOwned {
     /// Convert this type to shouty snake case.
     fn to_shouty_snake_case(&self) -> Self::Owned;
 }
 
-/// Oh heck, ShoutySnekCase is an alias for ShoutySnakeCase. See ShoutySnakeCase
-/// for more documentation.
-pub trait ShoutySnekCase: ToOwned {
+/// Oh heck, ToShoutySnekCase is an alias for ToShoutySnakeCase. See
+/// ToShoutySnakeCase for more documentation.
+pub trait ToShoutySnekCase: ToOwned {
     /// CONVERT THIS TYPE TO SNEK CASE.
     #[allow(non_snake_case)]
     fn TO_SHOUTY_SNEK_CASE(&self) -> Self::Owned;
 }
 
-impl<T: ?Sized + ShoutySnakeCase> ShoutySnekCase for T {
+impl<T: ?Sized + ToShoutySnakeCase> ToShoutySnekCase for T {
     fn TO_SHOUTY_SNEK_CASE(&self) -> Self::Owned {
         self.to_shouty_snake_case()
     }
 }
 
-impl ShoutySnakeCase for str {
+impl ToShoutySnakeCase for str {
     fn to_shouty_snake_case(&self) -> Self::Owned {
         transform(self, uppercase, |s| s.push('_'))
     }
@@ -40,7 +40,7 @@ impl ShoutySnakeCase for str {
 
 #[cfg(test)]
 mod tests {
-    use super::ShoutySnakeCase;
+    use super::ToShoutySnakeCase;
 
     macro_rules! t {
         ($t:ident : $s1:expr => $s2:expr) => {

--- a/src/shouty_snake.rs
+++ b/src/shouty_snake.rs
@@ -1,5 +1,5 @@
-use crate::{transform, uppercase, ConvertCaseOpt, Case};
 use crate::convert_case::convert_case;
+use crate::{transform, uppercase, Case, ConvertCaseOpt};
 
 /// This trait defines a shouty snake case conversion.
 ///
@@ -39,7 +39,13 @@ pub fn to_shouty_snake_case(s: &str, numbers_starts_word: bool) -> String {
 
 impl ToShoutySnakeCase for str {
     fn to_shouty_snake_case(&self) -> Self::Owned {
-        convert_case(&self, ConvertCaseOpt {case: Case::ShoutySnake, number_starts_word: false})
+        convert_case(
+            &self,
+            ConvertCaseOpt {
+                case: Case::ShoutySnake,
+                number_starts_word: false,
+            },
+        )
     }
 }
 

--- a/src/snake.rs
+++ b/src/snake.rs
@@ -1,4 +1,5 @@
-use crate::{lowercase, transform};
+use crate::{lowercase, transform, ConvertCaseOpt, Case};
+use crate::convert_case::convert_case;
 
 /// This trait defines a snake case conversion.
 ///
@@ -30,9 +31,13 @@ impl<T: ?Sized + ToSnakeCase> ToSnekCase for T {
     }
 }
 
+pub fn to_snake_case(s: &str, number_starts_word: bool) -> String {
+    transform(s, number_starts_word, lowercase, |s| s.push('_'))
+}
+
 impl ToSnakeCase for str {
-    fn to_snake_case(&self) -> String {
-        transform(self, lowercase, |s| s.push('_'))
+    fn to_snake_case(&self) -> Self::Owned {
+        convert_case(&self, ConvertCaseOpt {case: Case::Snake, number_starts_word: false})
     }
 }
 

--- a/src/snake.rs
+++ b/src/snake.rs
@@ -7,30 +7,30 @@ use crate::{lowercase, transform};
 /// ## Example:
 ///
 /// ```rust
-/// use heck::SnakeCase;
+/// use heck::ToSnakeCase;
 ///
 /// let sentence = "We carry a new world here, in our hearts.";
 /// assert_eq!(sentence.to_snake_case(), "we_carry_a_new_world_here_in_our_hearts");
 /// ```
-pub trait SnakeCase: ToOwned {
+pub trait ToSnakeCase: ToOwned {
     /// Convert this type to snake case.
     fn to_snake_case(&self) -> Self::Owned;
 }
 
-/// Oh heck, SnekCase is an alias for SnakeCase. See SnakeCase for
+/// Oh heck, SnekCase is an alias for ToSnakeCase. See ToSnakeCase for
 /// more documentation.
-pub trait SnekCase: ToOwned {
+pub trait ToSnekCase: ToOwned {
     /// Convert this type to snek case.
     fn to_snek_case(&self) -> Self::Owned;
 }
 
-impl<T: ?Sized + SnakeCase> SnekCase for T {
+impl<T: ?Sized + ToSnakeCase> ToSnekCase for T {
     fn to_snek_case(&self) -> Self::Owned {
         self.to_snake_case()
     }
 }
 
-impl SnakeCase for str {
+impl ToSnakeCase for str {
     fn to_snake_case(&self) -> String {
         transform(self, lowercase, |s| s.push('_'))
     }
@@ -38,7 +38,7 @@ impl SnakeCase for str {
 
 #[cfg(test)]
 mod tests {
-    use super::SnakeCase;
+    use super::ToSnakeCase;
 
     macro_rules! t {
         ($t:ident : $s1:expr => $s2:expr) => {

--- a/src/snake.rs
+++ b/src/snake.rs
@@ -1,5 +1,5 @@
-use crate::{lowercase, transform, ConvertCaseOpt, Case};
 use crate::convert_case::convert_case;
+use crate::{lowercase, transform, Case, ConvertCaseOpt};
 
 /// This trait defines a snake case conversion.
 ///
@@ -37,7 +37,13 @@ pub fn to_snake_case(s: &str, number_starts_word: bool) -> String {
 
 impl ToSnakeCase for str {
     fn to_snake_case(&self) -> Self::Owned {
-        convert_case(&self, ConvertCaseOpt {case: Case::Snake, number_starts_word: false})
+        convert_case(
+            &self,
+            ConvertCaseOpt {
+                case: Case::Snake,
+                number_starts_word: false,
+            },
+        )
     }
 }
 

--- a/src/title.rs
+++ b/src/title.rs
@@ -8,17 +8,17 @@ use crate::{capitalize, transform};
 /// ## Example:
 ///
 /// ```rust
-/// use heck::TitleCase;
+/// use heck::ToTitleCase;
 ///
 /// let sentence = "We have always lived in slums and holes in the wall.";
 /// assert_eq!(sentence.to_title_case(), "We Have Always Lived In Slums And Holes In The Wall");
 /// ```
-pub trait TitleCase: ToOwned {
+pub trait ToTitleCase: ToOwned {
     /// Convert this type to title case.
     fn to_title_case(&self) -> Self::Owned;
 }
 
-impl TitleCase for str {
+impl ToTitleCase for str {
     fn to_title_case(&self) -> String {
         transform(self, capitalize, |s| s.push(' '))
     }
@@ -26,7 +26,7 @@ impl TitleCase for str {
 
 #[cfg(test)]
 mod tests {
-    use super::TitleCase;
+    use super::ToTitleCase;
 
     macro_rules! t {
         ($t:ident : $s1:expr => $s2:expr) => {

--- a/src/title.rs
+++ b/src/title.rs
@@ -1,4 +1,5 @@
-use crate::{capitalize, transform};
+use crate::convert_case::convert_case;
+use crate::{capitalize, transform, Case, ConvertCaseOpt};
 
 /// This trait defines a title case conversion.
 ///
@@ -18,9 +19,19 @@ pub trait ToTitleCase: ToOwned {
     fn to_title_case(&self) -> Self::Owned;
 }
 
+pub fn to_title_case(s: &str, numbers_starts_word: bool) -> String {
+    transform(s, numbers_starts_word, capitalize, |s| s.push(' '))
+}
+
 impl ToTitleCase for str {
-    fn to_title_case(&self) -> String {
-        transform(self, capitalize, |s| s.push(' '))
+    fn to_title_case(&self) -> Self::Owned {
+        convert_case(
+            &self,
+            ConvertCaseOpt {
+                case: Case::Title,
+                number_starts_word: false,
+            },
+        )
     }
 }
 

--- a/src/upper_camel.rs
+++ b/src/upper_camel.rs
@@ -24,6 +24,19 @@ impl ToUpperCamelCase for str {
     }
 }
 
+/// ToPascalCase is an alias for ToUpperCamelCase. See ToUpperCamelCase for more
+/// documentation.
+pub trait ToPascalCase: ToOwned {
+    /// Convert this type to upper camel case.
+    fn to_pascal_case(&self) -> Self::Owned;
+}
+
+impl<T: ?Sized + ToUpperCamelCase> ToPascalCase for T {
+    fn to_pascal_case(&self) -> Self::Owned {
+        self.to_upper_camel_case()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::ToUpperCamelCase;

--- a/src/upper_camel.rs
+++ b/src/upper_camel.rs
@@ -1,4 +1,5 @@
-use crate::{capitalize, transform};
+use crate::{capitalize, transform, ConvertCaseOpt, Case};
+use crate::convert_case::convert_case;
 
 /// This trait defines an upper camel case conversion.
 ///
@@ -18,9 +19,13 @@ pub trait ToUpperCamelCase: ToOwned {
     fn to_upper_camel_case(&self) -> Self::Owned;
 }
 
+pub fn to_upper_camel_case(s: &str, numbers_starts_word: bool) -> String {
+    transform(s, numbers_starts_word, capitalize, |_| {})
+}
+
 impl ToUpperCamelCase for str {
-    fn to_upper_camel_case(&self) -> String {
-        transform(self, capitalize, |_| {})
+    fn to_upper_camel_case(&self) -> Self::Owned {
+        convert_case(&self, ConvertCaseOpt {case: Case::UpperCamel, number_starts_word: false})
     }
 }
 

--- a/src/upper_camel.rs
+++ b/src/upper_camel.rs
@@ -1,5 +1,5 @@
-use crate::{capitalize, transform, ConvertCaseOpt, Case};
 use crate::convert_case::convert_case;
+use crate::{capitalize, transform, Case, ConvertCaseOpt};
 
 /// This trait defines an upper camel case conversion.
 ///
@@ -25,7 +25,13 @@ pub fn to_upper_camel_case(s: &str, numbers_starts_word: bool) -> String {
 
 impl ToUpperCamelCase for str {
     fn to_upper_camel_case(&self) -> Self::Owned {
-        convert_case(&self, ConvertCaseOpt {case: Case::UpperCamel, number_starts_word: false})
+        convert_case(
+            &self,
+            ConvertCaseOpt {
+                case: Case::UpperCamel,
+                number_starts_word: false,
+            },
+        )
     }
 }
 

--- a/src/upper_camel.rs
+++ b/src/upper_camel.rs
@@ -1,38 +1,38 @@
 use crate::{capitalize, transform};
 
-/// This trait defines a camel case conversion.
+/// This trait defines an upper camel case conversion.
 ///
-/// In CamelCase, word boundaries are indicated by capital letters, including
-/// the first word.
+/// In UpperCamelCase, word boundaries are indicated by capital letters,
+/// including the first word.
 ///
 /// ## Example:
 ///
 /// ```rust
-/// use heck::ToCamelCase;
+/// use heck::ToUpperCamelCase;
 ///
 /// let sentence = "We are not in the least afraid of ruins.";
-/// assert_eq!(sentence.to_camel_case(), "WeAreNotInTheLeastAfraidOfRuins");
+/// assert_eq!(sentence.to_upper_camel_case(), "WeAreNotInTheLeastAfraidOfRuins");
 /// ```
-pub trait ToCamelCase: ToOwned {
-    /// Convert this type to camel case.
-    fn to_camel_case(&self) -> Self::Owned;
+pub trait ToUpperCamelCase: ToOwned {
+    /// Convert this type to upper camel case.
+    fn to_upper_camel_case(&self) -> Self::Owned;
 }
 
-impl ToCamelCase for str {
-    fn to_camel_case(&self) -> String {
+impl ToUpperCamelCase for str {
+    fn to_upper_camel_case(&self) -> String {
         transform(self, capitalize, |_| {})
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::ToCamelCase;
+    use super::ToUpperCamelCase;
 
     macro_rules! t {
         ($t:ident : $s1:expr => $s2:expr) => {
             #[test]
             fn $t() {
-                assert_eq!($s1.to_camel_case(), $s2)
+                assert_eq!($s1.to_upper_camel_case(), $s2)
             }
         };
     }


### PR DESCRIPTION
`ConvertCase` implements `convert_case()` which accepts customization options to tweak the behaviour of other case conversion functions. Currently, it accepts `number_starts_word` option to have word boundaries when characters in a word change from numeric to alphabetic or vice versa. 

Other case conversion functions are implemented in terms on `convert_case()` by passing `number_starts_word` as false by default. 

ref: https://github.com/withoutboats/heck/issues/18
ref: https://github.com/Peternator7/strum/issues/72

Closes #18 