### PR TITLE
Added AsXxxCase wrappers

### DIFF
--- a/src/kebab.rs
+++ b/src/kebab.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::{lowercase, transform};
 
 /// This trait defines a kebab case conversion.
@@ -19,7 +21,25 @@ pub trait ToKebabCase: ToOwned {
 
 impl ToKebabCase for str {
     fn to_kebab_case(&self) -> Self::Owned {
-        transform(self, lowercase, |s| s.push('-'))
+        AsKebabCase(self).to_string()
+    }
+}
+
+/// This wrapper performs a kebab case conversion in [`fmt::Display`].
+///
+/// ## Example:
+///
+/// ```
+/// use heck::AsKebabCase;
+///
+/// let sentence = "We are going to inherit the earth.";
+/// assert_eq!(format!("{}", AsKebabCase(sentence)), "we-are-going-to-inherit-the-earth");
+/// ```
+pub struct AsKebabCase<T: AsRef<str>>(pub T);
+
+impl<T: AsRef<str>> fmt::Display for AsKebabCase<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        transform(self.0.as_ref(), lowercase, |f| write!(f, "-"), f)
     }
 }
 

--- a/src/lower_camel.rs
+++ b/src/lower_camel.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::{capitalize, lowercase, transform};
 
 /// This trait defines a lower camel case conversion.
@@ -20,16 +22,37 @@ pub trait ToLowerCamelCase: ToOwned {
 
 impl ToLowerCamelCase for str {
     fn to_lower_camel_case(&self) -> String {
+        AsLowerCamelCase(self).to_string()
+    }
+}
+
+/// This wrapper performs a lower camel case conversion in [`fmt::Display`].
+///
+/// ## Example:
+///
+/// ```
+/// use heck::AsLowerCamelCase;
+///
+/// let sentence = "It is we who built these palaces and cities.";
+/// assert_eq!(format!("{}", AsLowerCamelCase(sentence)), "itIsWeWhoBuiltThesePalacesAndCities");
+/// ```
+pub struct AsLowerCamelCase<T: AsRef<str>>(pub T);
+
+impl<T: AsRef<str>> fmt::Display for AsLowerCamelCase<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut first = true;
         transform(
-            self,
-            |s, out| {
-                if out.is_empty() {
-                    lowercase(s, out);
+            self.0.as_ref(),
+            |s, f| {
+                if first {
+                    first = false;
+                    lowercase(s, f)
                 } else {
-                    capitalize(s, out)
+                    capitalize(s, f)
                 }
             },
-            |_| {},
+            |_| Ok(()),
+            f,
         )
     }
 }

--- a/src/shouty_kebab.rs
+++ b/src/shouty_kebab.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::{transform, uppercase};
 
 /// This trait defines a shouty kebab case conversion.
@@ -20,7 +22,25 @@ pub trait ToShoutyKebabCase: ToOwned {
 
 impl ToShoutyKebabCase for str {
     fn to_shouty_kebab_case(&self) -> Self::Owned {
-        transform(self, uppercase, |s| s.push('-'))
+        AsShoutyKebabCase(self).to_string()
+    }
+}
+
+/// This wrapper performs a kebab case conversion in [`fmt::Display`].
+///
+/// ## Example:
+///
+/// ```
+/// use heck::AsShoutyKebabCase;
+///
+/// let sentence = "We are going to inherit the earth.";
+/// assert_eq!(format!("{}", AsShoutyKebabCase(sentence)), "WE-ARE-GOING-TO-INHERIT-THE-EARTH");
+/// ```
+pub struct AsShoutyKebabCase<T: AsRef<str>>(pub T);
+
+impl<T: AsRef<str>> fmt::Display for AsShoutyKebabCase<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        transform(self.0.as_ref(), uppercase, |f| write!(f, "-"), f)
     }
 }
 

--- a/src/shouty_snake.rs
+++ b/src/shouty_snake.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::{transform, uppercase};
 
 /// This trait defines a shouty snake case conversion.
@@ -34,7 +36,25 @@ impl<T: ?Sized + ToShoutySnakeCase> ToShoutySnekCase for T {
 
 impl ToShoutySnakeCase for str {
     fn to_shouty_snake_case(&self) -> Self::Owned {
-        transform(self, uppercase, |s| s.push('_'))
+        AsShoutySnakeCase(self).to_string()
+    }
+}
+
+/// This wrapper performs a shouty snake  case conversion in [`fmt::Display`].
+///
+/// ## Example:
+///
+/// ```
+/// use heck::AsShoutySnakeCase;
+///
+/// let sentence = "That world is growing in this minute.";
+/// assert_eq!(format!("{}", AsShoutySnakeCase(sentence)), "THAT_WORLD_IS_GROWING_IN_THIS_MINUTE");
+/// ```
+pub struct AsShoutySnakeCase<T: AsRef<str>>(pub T);
+
+impl<T: AsRef<str>> fmt::Display for AsShoutySnakeCase<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        transform(self.0.as_ref(), uppercase, |f| write!(f, "_"), f)
     }
 }
 

--- a/src/snake.rs
+++ b/src/snake.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::{lowercase, transform};
 
 /// This trait defines a snake case conversion.
@@ -32,7 +34,25 @@ impl<T: ?Sized + ToSnakeCase> ToSnekCase for T {
 
 impl ToSnakeCase for str {
     fn to_snake_case(&self) -> String {
-        transform(self, lowercase, |s| s.push('_'))
+        AsSnakeCase(self).to_string()
+    }
+}
+
+/// This wrapper performs a snake case conversion in [`fmt::Display`].
+///
+/// ## Example:
+///
+/// ```
+/// use heck::AsSnakeCase;
+///
+/// let sentence = "We carry a new world here, in our hearts.";
+/// assert_eq!(format!("{}", AsSnakeCase(sentence)), "we_carry_a_new_world_here_in_our_hearts");
+/// ```
+pub struct AsSnakeCase<T: AsRef<str>>(pub T);
+
+impl<T: AsRef<str>> fmt::Display for AsSnakeCase<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        transform(self.0.as_ref(), lowercase, |f| write!(f, "_"), f)
     }
 }
 

--- a/src/title.rs
+++ b/src/title.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::{capitalize, transform};
 
 /// This trait defines a title case conversion.
@@ -20,7 +22,25 @@ pub trait ToTitleCase: ToOwned {
 
 impl ToTitleCase for str {
     fn to_title_case(&self) -> String {
-        transform(self, capitalize, |s| s.push(' '))
+        AsTitleCase(self).to_string()
+    }
+}
+
+/// This wrapper performs a title case conversion in [`fmt::Display`].
+///
+/// ## Example:
+///
+/// ```
+/// use heck::AsTitleCase;
+///
+/// let sentence = "We have always lived in slums and holes in the wall.";
+/// assert_eq!(format!("{}", AsTitleCase(sentence)), "We Have Always Lived In Slums And Holes In The Wall");
+/// ```
+pub struct AsTitleCase<T: AsRef<str>>(pub T);
+
+impl<T: AsRef<str>> fmt::Display for AsTitleCase<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        transform(self.0.as_ref(), capitalize, |f| write!(f, " "), f)
     }
 }
 

--- a/src/upper_camel.rs
+++ b/src/upper_camel.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::{capitalize, transform};
 
 /// This trait defines an upper camel case conversion.
@@ -20,7 +22,7 @@ pub trait ToUpperCamelCase: ToOwned {
 
 impl ToUpperCamelCase for str {
     fn to_upper_camel_case(&self) -> String {
-        transform(self, capitalize, |_| {})
+        AsUpperCamelCase(self).to_string()
     }
 }
 
@@ -34,6 +36,24 @@ pub trait ToPascalCase: ToOwned {
 impl<T: ?Sized + ToUpperCamelCase> ToPascalCase for T {
     fn to_pascal_case(&self) -> Self::Owned {
         self.to_upper_camel_case()
+    }
+}
+
+/// This wrapper performs a upper camel case conversion in [`fmt::Display`].
+///
+/// ## Example:
+///
+/// ```
+/// use heck::AsUpperCamelCase;
+///
+/// let sentence = "We are not in the least afraid of ruins.";
+/// assert_eq!(format!("{}", AsUpperCamelCase(sentence)), "WeAreNotInTheLeastAfraidOfRuins");
+/// ```
+pub struct AsUpperCamelCase<T: AsRef<str>>(pub T);
+
+impl<T: AsRef<str>> fmt::Display for AsUpperCamelCase<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        transform(self.0.as_ref(), capitalize, |_| Ok(()), f)
     }
 }
 


### PR DESCRIPTION
Given `camel: &str, snake: &str`, the following line allocates 3 `String`s:

```rust
format!("Camel is {} and snake is {}", camel.to_camel_case(), snake.to_snake_case())
```

Instead, I can write this to allocate only one `String`

```rust
println!("Camel is {} and snake is {}", AsCamelCase(camel), AsSnakeCase(snake));
```