### PR TITLE
Documentation correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ boundary is considered to be just prior to that uppercase character.
 2. If multiple uppercase characters are consecutive, they are considered to
 be within a single word, except that the last will be part of the next word
 if it is followed by lowercase characters (see rule 1).
-3. Non-alphabetic chraracters inherit the case of the preceding character
-for use in rules 1 and 2.
 
 That is, "HelloWorld" is segmented `Hello|World` whereas "XMLHttpRequest" is
 segmented `XML|Http|Request`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,6 @@
 //! 2. If multiple uppercase characters are consecutive, they are considered to
 //! be within a single word, except that the last will be part of the next word
 //! if it is followed by lowercase characters (see rule 1).
-//! 3. Non-alphabetic chraracters inherit the case of the preceding character
-//! for use in rules 1 and 2.
 //!
 //! That is, "HelloWorld" is segmented `Hello|World` whereas "XMLHttpRequest" is
 //! segmented `XML|Http|Request`.


### PR DESCRIPTION
The rules regarding characters that are neither uppercase nor lowercase is a bit subtle (see #4), so rule 3 (that I added in my last commit) is not accurate. I can't come up with a concise way to describe it, so I would rather just remove the false information.

Here's a counterexample:

```rust
t!(test16: "abc123DEF456" => "abc123_def456");
t!(test19: "ABC123def456" => "abc123def456");
````

If rule 3 was to be believed, then "ABC123def456" should be segmented as `ABC12|3def456`