### PR TITLE
Add compactlowercase and COMPACTUPPERCASE casing rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `no_std` support.
 - Remove non-additive `unicode` feature. The library now uses `char::is_alphanumeric`
   instead of the `uncode-segmentation` library to determine word boundaries in all cases.
+- Add `compactlowercase` and `COMPACTUPPERCASE` casing rules.
 
 # 0.4.1
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ indicators are dropped, except insofar as CamelCase capitalizes the first word.
 6. Title Case
 7. SHOUTY-KEBAB-CASE
 8. Train-Case
+9. compactlowercase
+10. COMPACTUPPERCASE
 
 ## MSRV
 

--- a/src/compact_lower.rs
+++ b/src/compact_lower.rs
@@ -1,0 +1,87 @@
+use alloc::{
+    borrow::ToOwned,
+    fmt,
+    string::{String, ToString},
+};
+
+use crate::{lowercase, transform};
+
+/// This trait defines a compact lower case conversion.
+///
+/// In compactlowercase, word boundaries are omitted.
+///
+/// ## Example:
+///
+/// ```rust
+/// use heck::ToCompactLowercase;
+///
+/// let sentence = "We carry a new world here, in our hearts.";
+/// assert_eq!(sentence.to_compact_lowercase(), "wecarryanewworldhereinourhearts");
+/// ```
+pub trait ToCompactLowercase: ToOwned {
+    /// Convert this type to compact lowercase.
+    fn to_compact_lowercase(&self) -> Self::Owned;
+}
+
+impl ToCompactLowercase for str {
+    fn to_compact_lowercase(&self) -> String {
+        AsCompactLowercase(self).to_string()
+    }
+}
+
+/// This wrapper performs a compact lowercase conversion in [`fmt::Display`].
+///
+/// ## Example:
+///
+/// ```
+/// use heck::AsCompactLowercase;
+///
+/// let sentence = "We carry a new world here, in our hearts.";
+/// assert_eq!(format!("{}", AsCompactLowercase(sentence)), "wecarryanewworldhereinourhearts");
+/// ```
+pub struct AsCompactLowercase<T: AsRef<str>>(pub T);
+
+impl<T: AsRef<str>> fmt::Display for AsCompactLowercase<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        transform(self.0.as_ref(), lowercase, |_f| Ok(()), f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ToCompactLowercase;
+
+    macro_rules! t {
+        ($t:ident : $s1:expr => $s2:expr) => {
+            #[test]
+            fn $t() {
+                assert_eq!($s1.to_compact_lowercase(), $s2)
+            }
+        };
+    }
+
+    t!(test1: "CamelCase" => "camelcase");
+    t!(test2: "This is Human case." => "thisishumancase");
+    t!(test3: "MixedUP CamelCase, with some Spaces" => "mixedupcamelcasewithsomespaces");
+    t!(test4: "mixed_up_ snake_case with some _spaces" => "mixedupsnakecasewithsomespaces");
+    t!(test5: "kebab-case" => "kebabcase");
+    t!(test6: "SHOUTY_SNAKE_CASE" => "shoutysnakecase");
+    t!(test7: "snake_case" => "snakecase");
+    t!(test8: "this-contains_ ALLKinds OfWord_Boundaries" => "thiscontainsallkindsofwordboundaries");
+    t!(test9: "XΣXΣ baﬄe" => "xσxςbaﬄe");
+    t!(test10: "XMLHttpRequest" => "xmlhttprequest");
+    t!(test11: "FIELD_NAME11" => "fieldname11");
+    t!(test12: "99BOTTLES" => "99bottles");
+    t!(test13: "FieldNamE11" => "fieldname11");
+    t!(test14: "abc123def456" => "abc123def456");
+    t!(test16: "abc123DEF456" => "abc123def456");
+    t!(test17: "abc123Def456" => "abc123def456");
+    t!(test18: "abc123DEf456" => "abc123def456");
+    t!(test19: "ABC123def456" => "abc123def456");
+    t!(test20: "ABC123DEF456" => "abc123def456");
+    t!(test21: "ABC123Def456" => "abc123def456");
+    t!(test22: "ABC123DEf456" => "abc123def456");
+    t!(test23: "ABC123dEEf456FOO" => "abc123deef456foo");
+    t!(test24: "abcDEF" => "abcdef");
+    t!(test25: "ABcDE" => "abcde");
+}

--- a/src/compact_upper.rs
+++ b/src/compact_upper.rs
@@ -1,0 +1,87 @@
+use alloc::{
+    borrow::ToOwned,
+    fmt,
+    string::{String, ToString},
+};
+
+use crate::{transform, uppercase};
+
+/// This trait defines a compact upper case conversion.
+///
+/// In COMPACTUPPERCASE, word boundaries are omitted.
+///
+/// ## Example:
+///
+/// ```rust
+/// use heck::ToCompactUppercase;
+///
+/// let sentence = "We carry a new world here, in our hearts.";
+/// assert_eq!(sentence.to_compact_uppercase(), "WECARRYANEWWORLDHEREINOURHEARTS");
+/// ```
+pub trait ToCompactUppercase: ToOwned {
+    /// Convert this type to compact lowercase.
+    fn to_compact_uppercase(&self) -> Self::Owned;
+}
+
+impl ToCompactUppercase for str {
+    fn to_compact_uppercase(&self) -> String {
+        AsCompactUppercase(self).to_string()
+    }
+}
+
+/// This wrapper performs a compact uppercase conversion in [`fmt::Display`].
+///
+/// ## Example:
+///
+/// ```
+/// use heck::AsCompactUppercase;
+///
+/// let sentence = "We carry a new world here, in our hearts.";
+/// assert_eq!(format!("{}", AsCompactUppercase(sentence)), "WECARRYANEWWORLDHEREINOURHEARTS");
+/// ```
+pub struct AsCompactUppercase<T: AsRef<str>>(pub T);
+
+impl<T: AsRef<str>> fmt::Display for AsCompactUppercase<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        transform(self.0.as_ref(), uppercase, |_f| Ok(()), f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ToCompactUppercase;
+
+    macro_rules! t {
+        ($t:ident : $s1:expr => $s2:expr) => {
+            #[test]
+            fn $t() {
+                assert_eq!($s1.to_compact_uppercase(), $s2)
+            }
+        };
+    }
+
+    t!(test1: "CamelCase" => "CAMELCASE");
+    t!(test2: "This is Human case." => "THISISHUMANCASE");
+    t!(test3: "MixedUP CamelCase, with some Spaces" => "MIXEDUPCAMELCASEWITHSOMESPACES");
+    t!(test4: "mixed_up_ snake_case with some _spaces" => "MIXEDUPSNAKECASEWITHSOMESPACES");
+    t!(test5: "kebab-case" => "KEBABCASE");
+    t!(test6: "SHOUTY_SNAKE_CASE" => "SHOUTYSNAKECASE");
+    t!(test7: "snake_case" => "SNAKECASE");
+    t!(test8: "this-contains_ ALLKinds OfWord_Boundaries" => "THISCONTAINSALLKINDSOFWORDBOUNDARIES");
+    t!(test9: "XΣXΣ baﬄe" => "XΣXΣBAFFLE");
+    t!(test10: "XMLHttpRequest" => "XMLHTTPREQUEST");
+    t!(test11: "FIELD_NAME11" => "FIELDNAME11");
+    t!(test12: "99BOTTLES" => "99BOTTLES");
+    t!(test13: "FieldNamE11" => "FIELDNAME11");
+    t!(test14: "abc123def456" => "ABC123DEF456");
+    t!(test16: "abc123DEF456" => "ABC123DEF456");
+    t!(test17: "abc123Def456" => "ABC123DEF456");
+    t!(test18: "abc123DEf456" => "ABC123DEF456");
+    t!(test19: "ABC123def456" => "ABC123DEF456");
+    t!(test20: "ABC123DEF456" => "ABC123DEF456");
+    t!(test21: "ABC123Def456" => "ABC123DEF456");
+    t!(test22: "ABC123DEf456" => "ABC123DEF456");
+    t!(test23: "ABC123dEEf456FOO" => "ABC123DEEF456FOO");
+    t!(test24: "abcDEF" => "ABCDEF");
+    t!(test25: "ABcDE" => "ABCDE");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@
 extern crate alloc;
 
 mod compact_lower;
+mod compact_upper;
 mod kebab;
 mod lower_camel;
 mod shouty_kebab;
@@ -53,6 +54,7 @@ mod train;
 mod upper_camel;
 
 pub use compact_lower::{AsCompactLowercase, ToCompactLowercase};
+pub use compact_upper::{AsCompactUppercase, ToCompactUppercase};
 pub use kebab::{AsKebabCase, ToKebabCase};
 pub use lower_camel::{AsLowerCamelCase, ToLowerCamelCase};
 pub use shouty_kebab::{AsShoutyKebabCase, ToShoutyKebabCase};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@
 
 extern crate alloc;
 
+mod compact_lower;
 mod kebab;
 mod lower_camel;
 mod shouty_kebab;
@@ -51,6 +52,7 @@ mod title;
 mod train;
 mod upper_camel;
 
+pub use compact_lower::{AsCompactLowercase, ToCompactLowercase};
 pub use kebab::{AsKebabCase, ToKebabCase};
 pub use lower_camel::{AsLowerCamelCase, ToLowerCamelCase};
 pub use shouty_kebab::{AsShoutyKebabCase, ToShoutyKebabCase};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@
 //! 6. Title Case
 //! 7. SHOUTY-KEBAB-CASE
 //! 8. Train-Case
+//! 9. compactlowercase
+//! 10. COMPACTUPPERCASE
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 #![no_std]


### PR DESCRIPTION
These rules transform the input case and eliminate spacing. Motivating example: (from https://github.com/serde-rs/serde/issues/2153#issuecomment-1717385764):

I'm consuming an API which has objects with fields firstname, lastname, streetnumber, and the like. In a perfect world, I could write this as

```rust
#[derive(Debug, Deserialize, Serialize)]
#[serde(rename_all="lowercase")]
struct FromForeignApi {
    first_name: String,
    last_name: String,
    street_number: String,
    // etc
}
```

However, attempting this, I encounter the surprising situation that unlike most rename_all rules, lowercase does not adjust the spacing between the words.